### PR TITLE
chore: Travis CI 빌드시 저장소 캐시 처리

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
 script: "mvn -P daily-build clean compile cobertura:cobertura"
 env:
   - TERM=dumb
+cache:
+  directories:
+    - $HOME/.m2
 after_success:
   - mvn -P daily-build coveralls:report
 notifications:


### PR DESCRIPTION
 빌드가 10분이상 걸리는 경우를 보면 라이브러리 다운로드가 대부분이기 때문에
 저장소를 캐시로 등록해둠
 https://docs.travis-ci.com/user/caching/#Arbitrary-directories

 추가적으로 스냅샷은 꼭 필요한 경우만 해야할듯.. (스냅샷은 항상 받아오기때문에)

 closes #17
