### PR TITLE
회원 기본 API 

### DIFF
--- a/src/main/java/io/codechobo/member/application/MemberService.java
+++ b/src/main/java/io/codechobo/member/application/MemberService.java
@@ -1,0 +1,73 @@
+package io.codechobo.member.application;
+
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.PointPerLevel;
+import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.constraints.NotNull;
+import java.util.Calendar;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:12
+ */
+public class MemberService {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    public List<MemberDto> getMembers() {
+        List<Member> member = memberRepository.findAll();
+
+        return member.stream()
+                .map(m -> new MemberDto(m.getSeq(), m.getId(), m.getPassword(), m.getEmail(), m.getNickName(), m.getRegistrationDate(), m.getPoint()))
+                .collect(Collectors.toList());
+    }
+
+    public MemberDto getMember(final Long sequence) {
+        Member member = memberRepository.findOne(sequence);
+
+        if(member == null) return null;
+
+        return new MemberDto(member.getSeq(), member.getId(), member.getPassword(), member.getEmail(), member.getNickName(), member.getRegistrationDate(), member.getPoint());
+    }
+
+    public MemberDto createMember(final MemberDto memberDto) {
+        Member member = new Member(memberDto);
+
+        if(member.getPoint() == null)
+            member.setPoint(new Integer(0));
+
+        if(member.getRegistrationDate() == null)
+            member.setRegistrationDate(Calendar.getInstance().getTime());
+
+        member.setLevel(PointPerLevel.valueOf(member.getPoint()));
+
+        member = memberRepository.save(member);
+
+        return new MemberDto(member.getSeq(), member.getId(), member.getPassword(), member.getEmail(), member.getNickName(), member.getRegistrationDate(), member.getPoint());
+    }
+
+    public MemberDto updateMember(MemberDto memberDto) {
+        if(memberDto.getSequence() == null || !memberRepository.exists(memberDto.getSequence())) {
+            throw new IllegalArgumentException();
+        }
+
+        memberDto.setLevel(PointPerLevel.valueOf(memberDto.getPoint()));
+
+        Member member = memberRepository.save(new Member(memberDto));
+
+        return new MemberDto(member.getSeq(), member.getId(), member.getPassword(), member.getEmail(), member.getNickName(), member.getRegistrationDate(), member.getPoint());
+    }
+
+    public void deleteMember(@NotNull final Long memberSequence) {
+        if(memberSequence == null) {
+            throw new IllegalArgumentException();
+        }
+
+        memberRepository.delete(memberSequence);
+    }
+}

--- a/src/main/java/io/codechobo/member/domain/Member.java
+++ b/src/main/java/io/codechobo/member/domain/Member.java
@@ -1,25 +1,12 @@
 package io.codechobo.member.domain;
 
 
+import io.codechobo.member.domain.support.MemberDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
-import javax.persistence.PrePersist;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import java.util.ArrayList;
+import javax.persistence.*;
 import java.util.Date;
 import java.util.List;
 
@@ -68,38 +55,22 @@ public class Member {
     /*
      * social은 member에 종속적이므로 cascade
      */
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumn(name = "SOCIAL_SEQ")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "seq")
     private List<Social> socials;
 
-    public Member(String id, String password, String nickName, String email, Integer point, ArrayList<Social> socials) {
-        this.id = id;
-        this.password = password;
-        this.nickName = nickName;
-        this.email = email;
-        this.point = point;
-        this.level = PointPerLevel.valueOf(this.point);
-        this.socials = socials;
-        this.registrationDate = new Date();
+    public Member(final MemberDto memberDto) {
+        this.seq = memberDto.getSequence();
+        this.id = memberDto.getId();
+        this.password = memberDto.getPassword();
+        this.nickName = memberDto.getNickName();
+        this.email = memberDto.getEmail();
+        this.point = memberDto.getPoint();
+        this.level = memberDto.getLevel();
+        this.registrationDate = memberDto.getRegiDate();
     }
 
     @PrePersist
     public void tmpLevelPersist() {
         this.level = PointPerLevel.valueOf(this.point);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder("[");
-        builder.append("sequence : "+this.seq)
-                .append(", id : "+this.id)
-                .append(", password : "+this.password)
-                .append(", nickName : "+this.nickName)
-                .append(", email : "+this.email)
-                .append(", point : "+this.point)
-                .append(", level : "+this.level)
-                .append("]");
-
-        return builder.toString();
     }
 }

--- a/src/main/java/io/codechobo/member/domain/Member.java
+++ b/src/main/java/io/codechobo/member/domain/Member.java
@@ -6,7 +6,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import java.util.Date;
 import java.util.List;
 
@@ -69,8 +79,4 @@ public class Member {
         this.registrationDate = memberDto.getRegiDate();
     }
 
-    @PrePersist
-    public void tmpLevelPersist() {
-        this.level = PointPerLevel.valueOf(this.point);
-    }
 }

--- a/src/main/java/io/codechobo/member/domain/PointPerLevel.java
+++ b/src/main/java/io/codechobo/member/domain/PointPerLevel.java
@@ -20,9 +20,6 @@ public enum PointPerLevel {
         this.max = max;
     }
 
-    public int getMin() {return this.min;}
-    public int getMax() {return this.max;}
-
     public static PointPerLevel valueOf(int point) {
         if(0 <= point && point < 100) return BASIC;
         else if(100 <= point && point < 200) return STANDARD;

--- a/src/main/java/io/codechobo/member/domain/Social.java
+++ b/src/main/java/io/codechobo/member/domain/Social.java
@@ -1,6 +1,7 @@
 package io.codechobo.member.domain;
 
 
+import io.codechobo.member.domain.support.SocialDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -38,15 +39,9 @@ public class Social {
     @JoinColumn(name = "MEMBER_SEQ")
     private Member member;
 
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder("[");
-        builder.append("seq : "+this.seq)
-                .append(", type : "+this.type)
-                .append(", token : "+this.token)
-                .append(", member : "+this.member)
-                .append("]");
-
-        return builder.toString();
+    public Social(final SocialDto socialDto) {
+        this.seq = socialDto.getSequence();
+        this.type = socialDto.getType();
+        this.token = socialDto.getToken();
     }
 }

--- a/src/main/java/io/codechobo/member/domain/support/MemberDto.java
+++ b/src/main/java/io/codechobo/member/domain/support/MemberDto.java
@@ -1,0 +1,49 @@
+package io.codechobo.member.domain.support;
+
+import io.codechobo.member.domain.PointPerLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:13
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberDto {
+    private Long sequence;
+    private String id;
+    private String password;
+    private String email;
+    private String nickName;
+    private Date regiDate;
+    private Integer point;
+    private PointPerLevel level;
+
+    public MemberDto(final Long sequence) {
+        this.sequence = sequence;
+    }
+
+    public MemberDto(final String id, final String password, final String email, final String nickName) {
+        this(null, id, password, email, nickName, null, 0);
+    }
+
+    public MemberDto(final String id, final String password, final String email, final String nickName, final Date regiDate, final Integer point) {
+        this(null, id, password, email, nickName, regiDate, point);
+    }
+
+    public MemberDto(final Long sequence, final String id, final String password, final String email, final String nickName, final Date regiDate, final Integer point) {
+        this.sequence = sequence;
+        this.id = id;
+        this.password = password;
+        this.email = email;
+        this.nickName = nickName;
+        this.regiDate = regiDate;
+        this.point = point;
+        this.level = PointPerLevel.valueOf(this.point);
+    }
+}

--- a/src/main/java/io/codechobo/member/domain/support/SocialDto.java
+++ b/src/main/java/io/codechobo/member/domain/support/SocialDto.java
@@ -1,0 +1,34 @@
+package io.codechobo.member.domain.support;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:15
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class SocialDto {
+    private Long sequence;
+    private String type;
+    private String token;
+    private Long memberSequence;
+
+    public SocialDto(final Long sequence) {
+        this.sequence = sequence;
+    }
+
+    public SocialDto(final String type, final String token, final Long memberSequence) {
+        this(null, type, token, memberSequence);
+    }
+
+    public SocialDto(final Long sequence, final String type, final String token, final Long memberSequence) {
+        this.sequence = sequence;
+        this.type = type;
+        this.token = token;
+        this.memberSequence = memberSequence;
+    }
+}

--- a/src/main/java/io/codechobo/member/interfaces/api/MemberRestController.java
+++ b/src/main/java/io/codechobo/member/interfaces/api/MemberRestController.java
@@ -1,0 +1,46 @@
+package io.codechobo.member.interfaces.api;
+
+import io.codechobo.member.application.MemberService;
+import io.codechobo.member.domain.support.MemberDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:17
+ */
+@RestController
+@RequestMapping("/api/member")
+public class MemberRestController {
+    @Autowired
+    MemberService memberService;
+
+    @RequestMapping(value = {"","/"}, method = RequestMethod.POST)
+    public ResponseEntity save(@RequestBody MemberDto memberDto) {
+        return new ResponseEntity(memberService.createMember(memberDto), HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
+    public ResponseEntity show() {
+        return new ResponseEntity(memberService.getMembers(), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/{seq}", method = RequestMethod.GET)
+    public ResponseEntity show(@PathVariable Long seq) {
+        return new ResponseEntity(memberService.getMember(seq), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/{seq}", method = RequestMethod.PUT)
+    public ResponseEntity update(@PathVariable Long seq, @RequestBody MemberDto memberDto) {
+        memberDto.setSequence(seq);
+        return new ResponseEntity(memberService.updateMember(memberDto), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/{seq}", method = RequestMethod.DELETE)
+    public ResponseEntity delete(@PathVariable Long seq) {
+        memberService.deleteMember(seq);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/src/test/java/io/codechobo/member/application/MemberServiceIntegrationTest.java
+++ b/src/test/java/io/codechobo/member/application/MemberServiceIntegrationTest.java
@@ -1,0 +1,63 @@
+package io.codechobo.member.application;
+
+import io.codechobo.member.domain.PointPerLevel;
+import io.codechobo.member.domain.support.MemberDto;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Calendar;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:19
+ */
+public class MemberServiceIntegrationTest {
+    @Autowired
+    MemberService memberService;
+
+    @Test
+    public void 멤버등록_테스트_crate_member() {
+        final MemberDto dto = generateData();
+        final MemberDto member = memberService.createMember(dto);
+
+        assertNotNull(member);
+        assertThat(member.getNickName(), is("nickName"));
+        System.out.println(member.getLevel());
+    }
+
+    @Test
+    public void 멤버_업데이트_update_member() {
+        final MemberDto dto = generateData();
+        final MemberDto member = memberService.createMember(dto);
+
+        final MemberDto updateDto = new MemberDto(member.getSequence(), member.getId(), "another password", "loustler@gmail.com", "loustler", Calendar.getInstance().getTime(), new Integer(100));
+        memberService.updateMember(updateDto);
+
+        final MemberDto updateMember = memberService.getMember(member.getSequence());
+
+        assertNotNull(updateMember);
+        assertThat(updateMember.getNickName(), is("loustler"));
+        assertThat(updateMember.getLevel(), is(PointPerLevel.STANDARD));
+    }
+
+    @Test
+    public void 멤버_삭제_remove_member() {
+        final MemberDto dto = generateData();
+        final MemberDto member = memberService.createMember(dto);
+
+        memberService.deleteMember(member.getSequence());
+
+        MemberDto after = memberService.getMember(member.getSequence());
+
+        assertNull(after);
+    }
+
+    private MemberDto generateData() {
+        return new MemberDto("id", "password", "email@gmail.com", "nickName", Calendar.getInstance().getTime(), new Integer(0));
+    }
+}

--- a/src/test/java/io/codechobo/member/domain/MemberIntegrationTest.java
+++ b/src/test/java/io/codechobo/member/domain/MemberIntegrationTest.java
@@ -1,8 +1,7 @@
-package io.codechobo.member;
+package io.codechobo.member.domain;
 
-import io.codechobo.member.domain.Member;
-import io.codechobo.member.domain.PointPerLevel;
 import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,10 +11,16 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Calendar;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+/**
+ * @author loustler
+ * @since 10/02/2016 10:21
+ */
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @ActiveProfiles(value = "test")
@@ -36,14 +41,12 @@ public class MemberIntegrationTest {
     }
 
     @Test
-    public void 설정확인_config_test() {
-        System.out.println(this.member);
-    }
+    public void 설정확인_config_test() {}
 
     @Test
     public void 멤버생성_create_new_member() {
         // given
-        Member member = new Member("test", "password", "loustler2", "dev.loustler@gmail.com", new Integer(0), null);
+        Member member = new Member(new MemberDto("test", "password", "dev.loustler@gmail.com", "loustler", Calendar.getInstance().getTime(), new Integer(0)));
 
         //when
         Member saveMember = memberRepository.save(member);
@@ -84,7 +87,7 @@ public class MemberIntegrationTest {
     @Test
     public void 멤버레벨업_level_up_member() {
         // given
-        Member newMember = new Member("any2", "password", "anonymouse2", "email2@gmail.com", new Integer(500), null);
+        Member newMember = new Member(new MemberDto("any2", "password", "email2@gmail.com", "anonymouse2", Calendar.getInstance().getTime(), new Integer(500)));
 
         // when
         memberRepository.save(newMember);
@@ -111,7 +114,7 @@ public class MemberIntegrationTest {
     }
 
     private Member memberFactory() {
-        Member member = new Member("any1", "password", "anonymouse", "email@gmail.com", new Integer(0), null);
+        Member member = new Member(new MemberDto("any1", "password", "email@gmail.com", "anonymouse", Calendar.getInstance().getTime(), new Integer(0)));
         return memberRepository.save(member);
     }
 }

--- a/src/test/java/io/codechobo/member/domain/SocialIntegrationTest.java
+++ b/src/test/java/io/codechobo/member/domain/SocialIntegrationTest.java
@@ -1,9 +1,8 @@
-package io.codechobo.member;
+package io.codechobo.member.domain;
 
-import io.codechobo.member.domain.Member;
-import io.codechobo.member.domain.Social;
 import io.codechobo.member.domain.repository.MemberRepository;
 import io.codechobo.member.domain.repository.SocialRepository;
+import io.codechobo.member.domain.support.MemberDto;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,13 +12,19 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
+/**
+ * @author loustler
+ * @since 10/02/2016 10:21
+ */
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @ActiveProfiles(value = "test")
@@ -30,13 +35,17 @@ public class SocialIntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    private Member member;
+    protected Member member;
     private Social social;
+
+    private Date now;
 
     @Before
     public void setUp() {
         this.member = memberFactory();
         this.social = socialFactory();
+
+        this.now = Calendar.getInstance().getTime();
 
         List<Social> socialList = new ArrayList<>();
         socialList.add(this.social);
@@ -47,6 +56,10 @@ public class SocialIntegrationTest {
 
     @Test
     public void 설정테스트_config_test() {
+        this.member.getSocials().stream()
+                .forEach(e -> System.out.println(e.getMember().getSeq()));
+
+        System.out.println(this.member.getSeq());
     }
 
     @Test
@@ -74,7 +87,7 @@ public class SocialIntegrationTest {
     public void 소셜가져오기_social_find() {
 
         // given
-        Member newMember = new Member("id1", "password2", "nickName3", "email@3.com", new Integer(0), new ArrayList<>());
+        Member newMember = new Member(new MemberDto("id1", "password2", "email@gmail.com", "nickName3", this.now, new Integer(0)));
 
         this.memberRepository.save(newMember);
 
@@ -95,8 +108,7 @@ public class SocialIntegrationTest {
     }
 
     private Member memberFactory() {
-        Member member = new Member("anyone", "password", "anonoymouse", "email@provider.com", new Integer(0), null);
-        return memberRepository.save(member);
+        return memberRepository.save(new Member(new MemberDto("anyone", "password", "email@provider.com", "anonymouse", this.now, new Integer(0))));
     }
 
     private Social socialFactory() {

--- a/src/test/java/io/codechobo/member/domain/SocialIntegrationTest.java
+++ b/src/test/java/io/codechobo/member/domain/SocialIntegrationTest.java
@@ -35,7 +35,7 @@ public class SocialIntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    protected Member member;
+    private Member member;
     private Social social;
 
     private Date now;

--- a/src/test/java/io/codechobo/member/interfaces/MemberRestControllerIntegrationTest.java
+++ b/src/test/java/io/codechobo/member/interfaces/MemberRestControllerIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.codechobo.member.interfaces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codechobo.member.application.MemberService;
+import io.codechobo.member.domain.support.MemberDto;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/**
+ * @author loustler
+ * @since 10/02/2016 10:28
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@WebAppConfiguration
+@ActiveProfiles(profiles = "test")
+public class MemberRestControllerIntegrationTest {
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Before
+    public void setUp() {
+        this.mvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    public void 설정_테스트_config_test() {}
+
+    @Test
+    public void 멤버_등록_create_member_via_create() throws Exception{
+        MemberDto memberDto = new MemberDto("id", "password", "email@gmail.com", "닉네임");
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(memberDto);
+        System.out.println(json);
+        mvc.perform(post("/api/member")
+                .content(json)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void 멤버_가져오기_get_member() throws Exception {
+        MemberDto memberDto = new MemberDto("id", "password", "email@gmail.com", "닉네임");
+        MemberDto member = memberService.createMember(memberDto);
+
+        mvc.perform(get("/api/member/"+member.getSequence()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 멤버_업데이트_update_member() throws Exception {
+        MemberDto memberDto = new MemberDto("id", "password", "email@gmail.com", "닉네임");
+        MemberDto member = memberService.createMember(memberDto);
+
+        member.setPassword("pwd");
+        member.setEmail("dev.loustler@gmail.com");
+        member.setNickName("loustler");
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(member);
+
+        mvc.perform(put("/api/member/"+member.getSequence())
+                .content(json)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 멤버_삭제_delete_member() throws Exception {
+        MemberDto memberDto = new MemberDto("id", "password", "email@gmail.com", "닉네임");
+        MemberDto member = memberService.createMember(memberDto);
+
+        mvc.perform(delete("/api/member/"+member.getSequence()))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
회원 기본 API 

회원쪽만 작성하였고, 소셜은 진행 예정

소셜 진행 방식에 대해 고민 중
- `toString()` override 제거
- `Service Layer`에서 point control
- `DTO Constructor` overloading
- `@PrePersist` 제거 후 `Service Layer`에서 처리 
- 접근제어자 `protected`에서 `private`로 수정
- `Member` domain Social List를 `mappedBy`로 수정 
