### PR TITLE
Feature/event

### DIFF
--- a/src/main/java/io/codechobo/event/application/JoiningService.java
+++ b/src/main/java/io/codechobo/event/application/JoiningService.java
@@ -1,0 +1,38 @@
+package io.codechobo.event.application;
+
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.Joining;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.interfaces.api.support.JoiningDto;
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-08
+ */
+@Service
+public class JoiningService {
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    JoiningRepository joiningRepository;
+
+    @Transactional
+    public Joining save(Long eventId, Long memberSeq, JoiningDto joiningDto) {
+        Event event = eventRepository.findOne(eventId);
+        Member member = memberRepository.findOne(memberSeq);
+        Joining joining = new Joining(event, member, joiningDto);
+        event.addEventJoin(joining);
+
+        return joining;
+    }
+}

--- a/src/main/java/io/codechobo/event/application/WinningService.java
+++ b/src/main/java/io/codechobo/event/application/WinningService.java
@@ -1,0 +1,39 @@
+package io.codechobo.event.application;
+
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.Joining;
+import io.codechobo.event.domain.Winning;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.domain.repository.WinningRepository;
+import io.codechobo.event.interfaces.api.support.WinningDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Kj Nam
+ * @since 2016-10-03
+ */
+@Service
+public class WinningService {
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    WinningRepository winningRepository;
+
+    @Autowired
+    JoiningRepository joiningRepository;
+
+    @Transactional
+    public Winning save(Long eventId, Long joiningId, WinningDto winningDto) {
+        Event event = eventRepository.findOne(eventId);
+        Joining joining = joiningRepository.findOne(joiningId);
+        Winning winning = new Winning(winningDto);
+        winning.addJoins(joining);
+        event.addEventWins(winning);
+
+        return winning;
+    }
+}

--- a/src/main/java/io/codechobo/event/domain/Event.java
+++ b/src/main/java/io/codechobo/event/domain/Event.java
@@ -1,5 +1,6 @@
 package io.codechobo.event.domain;
 
+import io.codechobo.event.interfaces.api.support.EventDto;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -46,6 +47,9 @@ public class Event {
     @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
     private List<Joining> eventJoins = new ArrayList<>();
 
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
+    private List<Winning> eventWins = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     private EventStatus status;
 
@@ -68,10 +72,28 @@ public class Event {
         this.endDate = endDate;
     }
 
+    public Event(EventDto eventDto) {
+        this.id = eventDto.getId();
+        this.name = eventDto.getName();
+        this.description = eventDto.getDescription();
+        this.resourceUrl = eventDto.getResourceUrl();
+        this.category = eventDto.getCategory();
+        this.startDate = eventDto.getStartDate();
+        this.endDate = eventDto.getEndDate();
+        this.status = EventStatus.OPEN;
+    }
+
     public void addEventJoin(Joining joining) {
         this.eventJoins.add(joining);
         if (joining.getEvent() != this) {
             joining.setEvent(this);
+        }
+    }
+
+    public void addEventWins(Winning winning) {
+        this.eventWins.add(winning);
+        if (winning.getEvent() != this) {
+            winning.setEvent(this);
         }
     }
 

--- a/src/main/java/io/codechobo/event/domain/EventCategory.java
+++ b/src/main/java/io/codechobo/event/domain/EventCategory.java
@@ -1,5 +1,6 @@
 package io.codechobo.event.domain;
 
+import io.codechobo.event.interfaces.api.support.EventCategoryDto;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -35,6 +36,11 @@ public class EventCategory {
 
     public EventCategory(String name) {
         this.name = name;
+    }
+
+    public EventCategory(EventCategoryDto eventCategoryDto) {
+        this.id = eventCategoryDto.getId();
+        this.name = eventCategoryDto.getName();
     }
 
     public void addEvent(Event event) {

--- a/src/main/java/io/codechobo/event/domain/Joining.java
+++ b/src/main/java/io/codechobo/event/domain/Joining.java
@@ -1,5 +1,6 @@
 package io.codechobo.event.domain;
 
+import io.codechobo.event.interfaces.api.support.JoiningDto;
 import io.codechobo.member.domain.Member;
 import lombok.Getter;
 
@@ -25,7 +26,7 @@ import java.util.Date;
 public class Joining {
 
     @Id @GeneratedValue
-    @Column(name = "ENTRY_ID")
+    @Column(name = "JOIN_ID")
     private Long id;
 
     @ManyToOne
@@ -33,20 +34,28 @@ public class Joining {
     private Member member;
 
     @Temporal(TemporalType.TIMESTAMP)
-    private Date entryDate;
+    private Date joinDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "EVENT_ID")
     private Event event;
 
-    @ManyToOne
-    @JoinColumn(name = "WIN_ID", insertable = false, updatable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "WIN_ID")
     private Winning winning;
 
     protected Joining() {
     }
 
-    public Joining(Event event, Member member) {
+    public Joining(Event event, Member member, Date joinDate) {
+        this.member = member;
+        this.event = event;
+        this.joinDate = joinDate;
+    }
+
+    public Joining(Event event, Member member, JoiningDto joiningDto) {
+        this.id = joiningDto.getId();
+        this.joinDate = joiningDto.getJoinDate();
         this.event = event;
         this.member = member;
     }
@@ -60,8 +69,8 @@ public class Joining {
 
     public void setWinning(Winning winning) {
         this.winning = winning;
-        if (!winning.getEventJoins().contains(this)) {
-            winning.getEventJoins().add(this);
+        if (!winning.getJoins().contains(this)) {
+            winning.getJoins().add(this);
         }
     }
 }

--- a/src/main/java/io/codechobo/event/domain/Winning.java
+++ b/src/main/java/io/codechobo/event/domain/Winning.java
@@ -1,14 +1,20 @@
 package io.codechobo.event.domain;
 
+import io.codechobo.event.interfaces.api.support.WinningDto;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -19,28 +25,48 @@ import java.util.List;
  */
 @Entity
 @Getter
-@NoArgsConstructor
 public class Winning {
-
-    /*
-     * TODO: 당첨 엔티티 정의 재검토
-     * 이벤트 당첨 객체의 역할은
-     * 응모자 객체 사이에서 당첨을 (0...*)를 추첨하고 그 당첨 정보를 가진다.
-     *
-     * 어떤 속성을 가져야 하고, 어떤 연관관계를 맺어야 할 지 다시 고민 필요
-     */
 
     @Id @GeneratedValue
     @Column(name = "WIN_ID")
     private Long id;
 
-    @OneToMany
-    private List<Joining> eventJoins = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "EVENT_ID")
+    private Event event;
 
-    public void addEventJoin(Joining joining) {
-        this.eventJoins.add(joining);
+    @Temporal(TemporalType.DATE)
+    private Date winningDate;
+
+    @OneToMany(mappedBy = "winning")
+    private List<Joining> joins = new ArrayList<>();
+
+
+    protected Winning() {
+    }
+
+    public Winning(Event event, Joining joining, Date winningDate) {
+        this.event = event;
+//        this.eventJoins.add(joining);
+        this.winningDate = winningDate;
+    }
+
+    public Winning(WinningDto winningDto) {
+        this.id = winningDto.getId();
+        this.winningDate = winningDto.getWinningDate();
+    }
+
+    public void addJoins(Joining joining) {
+        this.joins.add(joining);
         if (joining.getWinning() != this) {
             joining.setWinning(this);
+        }
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+        if (!event.getEventJoins().contains(this)) {
+            event.getEventWins().add(this);
         }
     }
 }

--- a/src/main/java/io/codechobo/event/domain/repository/JoiningRepository.java
+++ b/src/main/java/io/codechobo/event/domain/repository/JoiningRepository.java
@@ -3,9 +3,14 @@ package io.codechobo.event.domain.repository;
 import io.codechobo.event.domain.Joining;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * @author Kj Nam
  * @since 2016-08-17
  */
 public interface JoiningRepository extends JpaRepository<Joining, Long> {
+    List<Joining> findByEventId(Long eventId);
+
+    List<Joining> findByMemberId(String memberId);
 }

--- a/src/main/java/io/codechobo/event/domain/repository/WinningRepository.java
+++ b/src/main/java/io/codechobo/event/domain/repository/WinningRepository.java
@@ -3,9 +3,12 @@ package io.codechobo.event.domain.repository;
 import io.codechobo.event.domain.Winning;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * @author Kj Nam
  * @since 2016-08-21
  */
 public interface WinningRepository extends JpaRepository<Winning, Long> {
+    List<Winning> findByEventId (Long eventId);
 }

--- a/src/main/java/io/codechobo/event/interfaces/EventCategoryController.java
+++ b/src/main/java/io/codechobo/event/interfaces/EventCategoryController.java
@@ -1,0 +1,47 @@
+package io.codechobo.event.interfaces;
+
+import io.codechobo.event.domain.EventCategory;
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.interfaces.api.support.EventCategoryDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-05
+ */
+@RestController
+@RequestMapping("/api/eventcategories")
+public class EventCategoryController {
+
+    @Autowired
+    EventCategoryRepository eventCategoryRepository;
+
+    @RequestMapping(value = {"", "/"}, method = RequestMethod.POST)
+    private ResponseEntity save(@RequestBody EventCategoryDto eventCategoryDto) {
+        return new ResponseEntity<>(eventCategoryRepository.save(new EventCategory(eventCategoryDto)), HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.PUT)
+    private ResponseEntity update(@PathVariable Long id, @RequestBody EventCategoryDto eventCategoryDto) {
+        return new ResponseEntity<>(eventCategoryRepository.save(new EventCategory(eventCategoryDto)), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.GET)
+    private ResponseEntity view(@PathVariable Long id) {
+        return new ResponseEntity<>(eventCategoryRepository.findOne(id), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.DELETE)
+    private ResponseEntity delete(@PathVariable Long id) {
+        // TODO 삭제 요청에 대한 처리. 리다이렉트
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/io/codechobo/event/interfaces/EventController.java
+++ b/src/main/java/io/codechobo/event/interfaces/EventController.java
@@ -1,0 +1,62 @@
+package io.codechobo.event.interfaces;
+
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.interfaces.api.support.EventDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-29
+ */
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @RequestMapping(value = {"", "/"}, method = RequestMethod.POST)
+    private ResponseEntity save(@RequestBody @Valid  EventDto eventDto, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            // throw  new IllegalArgumentException(bindingResult.getAllErrors().get(0).getDefaultMessage());
+            // FIXME 글로벌 advice 구현시 예외를 던지도록 수정
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        return new ResponseEntity<>(eventRepository.save(new Event(eventDto)), HttpStatus.CREATED);
+    }
+
+    @RequestMapping(value = {"", "/"})
+    private ResponseEntity list(Pageable pageable) {
+        return new ResponseEntity<>(eventRepository.findAll(), HttpStatus.OK);
+
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.GET)
+    private ResponseEntity view(@PathVariable Long id) {
+        return new ResponseEntity<>(eventRepository.findOne(id), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.PUT)
+    private ResponseEntity update(@PathVariable Long id, @RequestBody EventDto eventDto) {
+        return new ResponseEntity<>(eventRepository.save(new Event(eventDto)), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = {"/{id}"}, method = RequestMethod.DELETE)
+    private ResponseEntity delete(@PathVariable Long id) {
+        // TODO 삭제 요청에 대한 처리. 리다이렉트
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/io/codechobo/event/interfaces/JoiningController.java
+++ b/src/main/java/io/codechobo/event/interfaces/JoiningController.java
@@ -1,0 +1,35 @@
+package io.codechobo.event.interfaces;
+
+import io.codechobo.event.application.JoiningService;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.interfaces.api.support.JoiningDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-08
+ */
+@RestController
+@RequestMapping("/api/joins")
+public class JoiningController {
+
+    @Autowired
+    JoiningService joiningService;
+
+    @Autowired
+    JoiningRepository joiningRepository;
+
+    @RequestMapping(value = "/events/{eventId}/members/{memberSeq}", method = RequestMethod.POST)
+    public ResponseEntity addJoining(@PathVariable Long eventId,
+                                     @PathVariable Long memberSeq,
+                                     @RequestBody JoiningDto joiningDto) {
+        return new ResponseEntity<>(joiningService.save(eventId, memberSeq, joiningDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/io/codechobo/event/interfaces/WinningController.java
+++ b/src/main/java/io/codechobo/event/interfaces/WinningController.java
@@ -1,0 +1,40 @@
+package io.codechobo.event.interfaces;
+
+import io.codechobo.event.application.WinningService;
+import io.codechobo.event.domain.repository.WinningRepository;
+import io.codechobo.event.interfaces.api.support.WinningDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-10
+ */
+@RestController
+@RequestMapping("/api/wins")
+public class WinningController {
+
+    @Autowired
+    WinningRepository winningRepository;
+
+    @Autowired
+    WinningService winningService;
+
+    @RequestMapping(value = "/events/{eventId}/joins/{joinId}", method = RequestMethod.POST)
+    public ResponseEntity addWinning(@PathVariable Long eventId,
+                                     @PathVariable Long joinId,
+                                     @RequestBody WinningDto winningDto) {
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/events/{eventId}", method = RequestMethod.GET)
+    public ResponseEntity list(@PathVariable Long eventId) {
+        return new ResponseEntity(winningRepository.findByEventId(eventId), HttpStatus.OK);
+    }
+}

--- a/src/main/java/io/codechobo/event/interfaces/api/support/EventCategoryDto.java
+++ b/src/main/java/io/codechobo/event/interfaces/api/support/EventCategoryDto.java
@@ -1,0 +1,19 @@
+package io.codechobo.event.interfaces.api.support;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-05
+ */
+@Getter
+@Setter
+public class EventCategoryDto {
+    private Long id;
+
+    @NotNull
+    private String name;
+}

--- a/src/main/java/io/codechobo/event/interfaces/api/support/EventDto.java
+++ b/src/main/java/io/codechobo/event/interfaces/api/support/EventDto.java
@@ -1,0 +1,38 @@
+package io.codechobo.event.interfaces.api.support;
+
+import io.codechobo.event.domain.EventCategory;
+import io.codechobo.event.domain.EventStatus;
+import io.codechobo.event.domain.Joining;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-04
+ */
+@Getter
+@Setter
+public class EventDto {
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    private String resourceUrl;
+
+    private EventCategory category;
+
+    private String description;
+
+    private List<Joining> eventJoins;
+
+    private EventStatus status;
+
+    private Date startDate;
+
+    private Date endDate;
+}

--- a/src/main/java/io/codechobo/event/interfaces/api/support/JoiningDto.java
+++ b/src/main/java/io/codechobo/event/interfaces/api/support/JoiningDto.java
@@ -1,0 +1,17 @@
+package io.codechobo.event.interfaces.api.support;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-08
+ */
+@Getter
+@Setter
+public class JoiningDto {
+    Long id;
+    Date joinDate;
+}

--- a/src/main/java/io/codechobo/event/interfaces/api/support/WinningDto.java
+++ b/src/main/java/io/codechobo/event/interfaces/api/support/WinningDto.java
@@ -1,0 +1,34 @@
+package io.codechobo.event.interfaces.api.support;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-17
+ */
+@Setter
+@Getter
+public class WinningDto {
+    private Long id;
+
+    private Date winningDate;
+
+    public WinningDto() {
+    }
+
+    public WinningDto(Long id) {
+        this.id = id;
+    }
+
+    public WinningDto(Date winningDate) {
+        this.winningDate = winningDate;
+    }
+
+    public WinningDto(Long id, Date winningDate) {
+        this.id = id;
+        this.winningDate = winningDate;
+    }
+}

--- a/src/test/java/io/codechobo/event/domain/EventBuilder.java
+++ b/src/test/java/io/codechobo/event/domain/EventBuilder.java
@@ -1,0 +1,70 @@
+package io.codechobo.event.domain;
+
+import java.util.Date;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-29
+ */
+public class EventBuilder {
+
+    private Event event;
+
+    private EventBuilder() {
+        this.event = new Event();
+    }
+
+    public static EventBuilder anEvent() {
+        return new EventBuilder();
+    }
+
+    public Event build() {
+        return event;
+    }
+
+    public EventBuilder with이벤트명(String eventName) {
+        this.event.setName(eventName);
+        return this;
+    }
+
+    public EventBuilder with설명(String description) {
+        this.event.setDescription(description);
+        return this;
+    }
+
+    public EventBuilder with페이지주소(String resourceUrl) {
+        this.event.setResourceUrl(resourceUrl);
+        return this;
+    }
+
+    public EventBuilder with시작일(Date startDate) {
+        this.event.setStartDate(startDate);
+        return this;
+    }
+
+    public EventBuilder with종료일(Date endDate) {
+        this.event.setEndDate(endDate);
+        return this;
+    }
+
+    public EventBuilder with카테고리(EventCategory category) {
+        this.event.setCategory(category);
+        return this;
+    }
+
+    public EventBuilder with이벤트상태(EventStatus status) {
+        this.event.setStatus(status);
+        return this;
+    }
+
+    public EventBuilder but() {
+        return anEvent()
+                .with이벤트명(this.event.getName())
+                .with설명(this.event.getDescription())
+                .with페이지주소(this.event.getResourceUrl())
+                .with시작일(this.event.getStartDate())
+                .with종료일(this.event.getEndDate())
+                .with카테고리(this.event.getCategory())
+                .with이벤트상태(this.event.getStatus());
+    }
+}

--- a/src/test/java/io/codechobo/event/domain/EventCategoryIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/EventCategoryIntegrationTest.java
@@ -1,0 +1,71 @@
+package io.codechobo.event.domain;
+
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Date;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-28
+ */
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@ActiveProfiles(profiles = "test")
+public class EventCategoryIntegrationTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventCategoryRepository eventCategoryRepository;
+
+    private EventCategory 온라인카테고리;
+
+    private EventBuilder eventBuilder;
+
+    @Before
+    public void setUp() {
+        온라인카테고리 = new EventCategory("온라인");
+        eventCategoryRepository.save(온라인카테고리);
+
+        eventBuilder = anEvent()
+                     .with이벤트명("더블예매이벤트")
+                     .with설명("이벤트 설명 입니다")
+                     .with시작일(new Date())
+                     .with종료일(new Date())
+                     .with페이지주소("/event1")
+                     .with카테고리(온라인카테고리)
+                     .with이벤트상태(EventStatus.OPEN);
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void 한_카테고리에_여러_이벤트() {
+        Event 더블예매이벤트 = eventBuilder.build();
+        Event 기대평이벤트 = eventBuilder.but().with이벤트명("기대평이벤트").build();
+
+        //when
+        eventRepository.save(더블예매이벤트);
+        eventRepository.save(기대평이벤트);
+
+        //then
+        assertThat(온라인카테고리.getEvents().get(0).getName(), is("더블예매이벤트"));
+        assertThat(온라인카테고리.getEvents().get(1).getName(), is("기대평이벤트"));
+    }
+}

--- a/src/test/java/io/codechobo/event/domain/EventIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/EventIntegrationTest.java
@@ -1,0 +1,82 @@
+package io.codechobo.event.domain;
+
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Date;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-31
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@DataJpaTest
+@ActiveProfiles(profiles = "test")
+public class EventIntegrationTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventCategoryRepository eventCategoryRepository;
+
+    private EventCategory onlineCategory;
+    private EventBuilder eventBuilder;
+    private Event anEvent;
+
+    @Before
+    public void setUp() {
+        onlineCategory = new EventCategory("온라인");
+        eventCategoryRepository.save(onlineCategory);
+
+        eventBuilder = anEvent()
+                    .with이벤트명("더블예매이벤트")
+                    .with설명("이벤트 설명 입니다")
+                    .with시작일(new Date())
+                    .with종료일(new Date())
+                    .with페이지주소("/event1")
+                    .with카테고리(onlineCategory)
+                    .with이벤트상태(EventStatus.OPEN);
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void 이벤트_생성() {
+        //given
+        anEvent = eventBuilder.build();
+
+        //when
+        eventRepository.save(anEvent);
+
+        //then
+        assertThat(eventRepository.findAll().size(), is(1));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void 이벤트_생성간_존재하지_않는_카테고리_참조시_예외() {
+        //given
+        onlineCategory = null;
+        anEvent = eventBuilder.but().with카테고리(onlineCategory).build();
+
+        //when
+        eventRepository.save(anEvent);
+
+        //then
+        // exception
+    }
+}

--- a/src/test/java/io/codechobo/event/domain/JoiningIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/JoiningIntegrationTest.java
@@ -1,0 +1,109 @@
+package io.codechobo.event.domain;
+
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.repository.MemberRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Date;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-31
+ */
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@ActiveProfiles(profiles = "test")
+public class JoiningIntegrationTest {
+
+    @Autowired
+    private JoiningRepository joiningRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EventCategoryRepository categoryRepository;
+
+    private Member member1;
+    private Member member2;
+    private EventBuilder eventBuilder;
+    private EventCategory category;
+    private Event anEvent;
+    private Joining joining1;
+    private Joining joining2;
+
+    @Before
+    public void setUp() {
+        member1 = new Member("member1", "password", "닉네임1", "이메일1@gmail.com", new Integer(0), null);
+        member2 = new Member("member2", "password", "닉네임2", "이메일2@gmail.com", new Integer(0), null);
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        category = new EventCategory("온라인이벤트");
+        categoryRepository.save(category);
+
+        eventBuilder = anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with카테고리(category)
+                .with이벤트상태(EventStatus.OPEN);
+
+        anEvent = eventBuilder.build();
+        eventRepository.save(anEvent);
+    }
+
+    @After
+    public void tearDown() {
+        joiningRepository.deleteAll();
+    }
+
+    @Test
+    public void 한_이벤트_여려명_응모() {
+        //given
+        joining1 = new Joining(anEvent, member1);
+        joining2 = new Joining(anEvent, member2);
+
+        //when
+        joiningRepository.save(joining1);
+        joiningRepository.save(joining2);
+
+        //then
+        assertThat(joiningRepository.findByEventId(anEvent.getId()).size(), is(2));
+    }
+
+    @Test
+    public void 한명이_여러_이벤트_응모() {
+        //given
+        Event 새로운이벤트= eventBuilder.but().with이벤트명("새로운이벤트").build();
+        eventRepository.save(새로운이벤트);
+        joining1 = new Joining(anEvent, member1);
+        joining2 = new Joining(새로운이벤트, member1);
+
+        //when
+        joiningRepository.save(joining1);
+        joiningRepository.save(joining2);
+
+        //then
+        assertThat(joiningRepository.findByMemberId(member1.getId()).size(), is(2));
+    }
+}

--- a/src/test/java/io/codechobo/event/domain/JoiningIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/JoiningIntegrationTest.java
@@ -5,6 +5,7 @@ import io.codechobo.event.domain.repository.EventRepository;
 import io.codechobo.event.domain.repository.JoiningRepository;
 import io.codechobo.member.domain.Member;
 import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +19,7 @@ import java.util.Date;
 
 import static io.codechobo.event.domain.EventBuilder.anEvent;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author Kj Nam
@@ -51,8 +52,8 @@ public class JoiningIntegrationTest {
 
     @Before
     public void setUp() {
-        member1 = new Member("member1", "password", "닉네임1", "이메일1@gmail.com", new Integer(0), null);
-        member2 = new Member("member2", "password", "닉네임2", "이메일2@gmail.com", new Integer(0), null);
+        member1 = new Member(new MemberDto("member1", "password", "이메일1@gmail.com", "닉네임1"));
+        member2 = new Member(new MemberDto("member2", "password", "이메일2@gmail.com", "닉네임2"));
         memberRepository.save(member1);
         memberRepository.save(member2);
 
@@ -80,8 +81,8 @@ public class JoiningIntegrationTest {
     @Test
     public void 한_이벤트_여려명_응모() {
         //given
-        joining1 = new Joining(anEvent, member1);
-        joining2 = new Joining(anEvent, member2);
+        joining1 = new Joining(anEvent, member1, new Date());
+        joining2 = new Joining(anEvent, member2, new Date());
 
         //when
         joiningRepository.save(joining1);
@@ -94,10 +95,10 @@ public class JoiningIntegrationTest {
     @Test
     public void 한명이_여러_이벤트_응모() {
         //given
-        Event 새로운이벤트= eventBuilder.but().with이벤트명("새로운이벤트").build();
+        Event 새로운이벤트 = eventBuilder.but().with이벤트명("새로운이벤트").build();
         eventRepository.save(새로운이벤트);
-        joining1 = new Joining(anEvent, member1);
-        joining2 = new Joining(새로운이벤트, member1);
+        joining1 = new Joining(anEvent, member1, new Date());
+        joining2 = new Joining(새로운이벤트, member1, new Date());
 
         //when
         joiningRepository.save(joining1);

--- a/src/test/java/io/codechobo/event/domain/WinningIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/WinningIntegrationTest.java
@@ -6,6 +6,7 @@ import io.codechobo.event.domain.repository.JoiningRepository;
 import io.codechobo.event.domain.repository.WinningRepository;
 import io.codechobo.member.domain.Member;
 import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,10 +17,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Date;
+import java.util.List;
 
 import static io.codechobo.event.domain.EventBuilder.anEvent;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author Kj Nam
@@ -56,9 +58,9 @@ public class WinningIntegrationTest {
 
     @Before
     public void setUp() {
-        응모자1 = new Member("member1", "password", "닉네임1", "이메일1@gmail.com", new Integer(0), null);
+        응모자1 = new Member(new MemberDto("member1", "password", "이메일1@gmail.com", "닉네임1"));
         memberRepository.save(응모자1);
-        응모자2 = new Member("member2", "password", "닉네임2", "이메일2@gmail.com", new Integer(0), null);
+        응모자2 = new Member(new MemberDto("member2", "password", "이메일2@gmail.com", "닉네임2"));
         memberRepository.save(응모자2);
 
         category = new EventCategory("온라인이벤트");
@@ -76,10 +78,10 @@ public class WinningIntegrationTest {
         anEvent = eventBuilder.build();
         eventRepository.save(anEvent);
 
-        응모1 = new Joining(anEvent, 응모자1);
+        응모1 = new Joining(anEvent, 응모자1, new Date());
         joiningRepository.save(응모1);
 
-        응모2 = new Joining(anEvent, 응모자2);
+        응모2 = new Joining(anEvent, 응모자2, new Date());
         joiningRepository.save(응모2);
 
         winning = new Winning();
@@ -91,15 +93,18 @@ public class WinningIntegrationTest {
     }
 
     @Test
-    public void 당첨자_추가() {
+    public void 한_이벤트_여러명의_당첨자_추가() {
         //given
-        winning.addEventJoin(응모1);
-        winning.addEventJoin(응모2);
+        winning.addJoins(응모1);
+        winning.addJoins(응모2);
+        anEvent.addEventWins(winning);
 
         //when
         winningRepository.save(winning);
+        List<Joining> wins = winningRepository
+                .findByEventId(anEvent.getId()).get(0).getJoins();
 
         //then
-        assertThat(winning.getEventJoins().size(), is(2));
+        assertThat(wins.size(), is(2));
     }
 }

--- a/src/test/java/io/codechobo/event/domain/WinningIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/domain/WinningIntegrationTest.java
@@ -1,0 +1,105 @@
+package io.codechobo.event.domain;
+
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.domain.repository.WinningRepository;
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.repository.MemberRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Date;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-31
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@DataJpaTest
+@ActiveProfiles(profiles = "test")
+public class WinningIntegrationTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EventCategoryRepository categoryRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private JoiningRepository joiningRepository;
+
+    @Autowired
+    private WinningRepository winningRepository;
+
+    private EventBuilder eventBuilder;
+    private EventCategory category;
+    private Event anEvent;
+    private Joining 응모1;
+    private Joining 응모2;
+    private Member 응모자1;
+    private Member 응모자2;
+
+    private Winning winning;
+
+    @Before
+    public void setUp() {
+        응모자1 = new Member("member1", "password", "닉네임1", "이메일1@gmail.com", new Integer(0), null);
+        memberRepository.save(응모자1);
+        응모자2 = new Member("member2", "password", "닉네임2", "이메일2@gmail.com", new Integer(0), null);
+        memberRepository.save(응모자2);
+
+        category = new EventCategory("온라인이벤트");
+        categoryRepository.save(category);
+
+        eventBuilder = anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with카테고리(category)
+                .with이벤트상태(EventStatus.OPEN);
+
+        anEvent = eventBuilder.build();
+        eventRepository.save(anEvent);
+
+        응모1 = new Joining(anEvent, 응모자1);
+        joiningRepository.save(응모1);
+
+        응모2 = new Joining(anEvent, 응모자2);
+        joiningRepository.save(응모2);
+
+        winning = new Winning();
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void 당첨자_추가() {
+        //given
+        winning.addEventJoin(응모1);
+        winning.addEventJoin(응모2);
+
+        //when
+        winningRepository.save(winning);
+
+        //then
+        assertThat(winning.getEventJoins().size(), is(2));
+    }
+}

--- a/src/test/java/io/codechobo/event/interfaces/EventCategoryControllerIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/interfaces/EventCategoryControllerIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.codechobo.event.interfaces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codechobo.event.domain.EventBuilder;
+import io.codechobo.event.domain.EventCategory;
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.interfaces.api.support.EventCategoryDto;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-05
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@WebAppConfiguration
+@ActiveProfiles(profiles = "test")
+public class EventCategoryControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventCategoryRepository eventCategoryRepository;
+
+    private EventBuilder eventBuilder;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @After
+    public void tearDown() {
+        eventRepository.deleteAll();
+        eventCategoryRepository.deleteAll();
+    }
+
+    @Test
+    public void 이벤트_카테고리_등록_201() throws Exception {
+        //given
+        EventCategoryDto eventCategoryDto = new EventCategoryDto();
+        eventCategoryDto.setName("온라인이벤트");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(eventCategoryDto);
+
+        //when then
+        mockMvc.perform(post("/api/eventcategories")
+                .content(jsonContents)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void 이벤트_카테고리_상세조회_200() throws Exception {
+        //given
+        EventCategoryDto eventCategoryDto = new EventCategoryDto();
+        eventCategoryDto.setName("온라인이벤트");
+        EventCategory eventCategory = eventCategoryRepository.save(new EventCategory(eventCategoryDto));
+        assertThat(eventCategoryRepository.findAll().size(), is(1));
+
+        //when then
+        String body = mockMvc.perform(get("/api/eventcategories/" + eventCategory.getId()))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(body, is("{\"id\":" + eventCategory.getId() + ",\"name\":\"온라인이벤트\",\"events\":[]}"));
+    }
+
+    @Test
+    public void 이벤트_카테고리_수정_200() throws Exception {
+        //given
+        EventCategoryDto eventCategoryDto = new EventCategoryDto();
+        eventCategoryDto.setName("온라인이벤트");
+        EventCategory eventCategory = eventCategoryRepository.save(new EventCategory(eventCategoryDto));
+        assertThat(eventCategoryRepository.findAll().size(), is(1));
+
+        EventCategoryDto editCategoryDto = new EventCategoryDto();
+        editCategoryDto.setId(eventCategory.getId());
+        editCategoryDto.setName("수정됨");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(editCategoryDto);
+
+        //when then
+        mockMvc.perform(put("/api/eventcategories/" + eventCategory.getId())
+                .content(jsonContents)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 이벤트_카테고리_삭제_200() throws Exception {
+        //given
+        EventCategoryDto eventCategoryDto = new EventCategoryDto();
+        eventCategoryDto.setName("온라인이벤트");
+        EventCategory eventCategory = eventCategoryRepository.save(new EventCategory(eventCategoryDto));
+        assertThat(eventCategoryRepository.findAll().size(), is(1));
+
+        //when then
+        mockMvc.perform(delete("/api/eventcategories/" + eventCategory.getId()))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/io/codechobo/event/interfaces/EventControllerIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/interfaces/EventControllerIntegrationTest.java
@@ -1,0 +1,174 @@
+package io.codechobo.event.interfaces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.EventBuilder;
+import io.codechobo.event.domain.EventStatus;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.interfaces.api.support.EventDto;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Date;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Kj Nam
+ * @since 2016-08-29
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@WebAppConfiguration
+@ActiveProfiles(profiles = "test")
+public class EventControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+    private MockMvc mockMvc;
+
+    @Autowired
+    EventRepository eventRepository;
+    private Event anEvent;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void 새_이벤트_등록_201() throws Exception {
+        //given
+        EventDto dto = new EventDto();
+        dto.setName("추첨이벤트");
+        dto.setDescription("추첨이벤트 설명");
+        dto.setResourceUrl("/event1");
+        dto.setStartDate(new Date());
+        dto.setEndDate(new Date());
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(dto);
+
+        //when then
+        mockMvc.perform(post("/api/events")
+            .content(jsonContents)
+            .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void 이름_없는_이벤트_등록시_400() throws Exception {
+        //given
+        EventDto dto = new EventDto();
+        // dto.setName("");
+        dto.setDescription("추첨이벤트 설명");
+        dto.setResourceUrl("/event1");
+        dto.setStartDate(new Date());
+        dto.setEndDate(new Date());
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(dto);
+
+        //when then
+        mockMvc.perform(post("/api/events")
+                .content(jsonContents).contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void 이벤트_리스트_조회_200() throws Exception {
+        //given
+
+        //when then
+        mockMvc.perform(get("/api/events"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 이벤트_상세_조회_200() throws Exception {
+        //given
+        anEvent = eventRepository.save(EventBuilder.anEvent()
+                            .with이벤트명("더블예매이벤트")
+                            .with설명("이벤트 설명 입니다")
+                            .with시작일(new Date())
+                            .with종료일(new Date())
+                            .with페이지주소("/event1")
+                            .with이벤트상태(EventStatus.OPEN).build());
+        eventRepository.save(anEvent);
+
+        //when then
+        mockMvc.perform(get("/api/events/" + anEvent.getId()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 이벤트_정보_수정_200() throws Exception {
+        //given
+        anEvent = eventRepository.save(EventBuilder.anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with이벤트상태(EventStatus.OPEN).build());
+        eventRepository.save(anEvent);
+
+        EventDto eventDto = new EventDto();
+        eventDto.setId(anEvent.getId());
+        eventDto.setName("수정된예매이벤트");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(eventDto);
+
+        //when then
+        String body = mockMvc.perform(put("/api/events/" + anEvent.getId())
+                .content(jsonContents)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(body, containsString(eventDto.getName()));
+    }
+
+    @Test
+    public void 잘못된_요청_400() throws Exception {
+        //given
+
+        //when then
+        mockMvc.perform(get("/api/events/abcdef"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void 이벤트_정보_삭제_200() throws Exception {
+        anEvent = eventRepository.save(EventBuilder.anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with이벤트상태(EventStatus.OPEN).build());
+        eventRepository.save(anEvent);
+
+        //when then
+        mockMvc.perform(delete("/api/events/" + anEvent.getId()))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/io/codechobo/event/interfaces/JoiningControllerIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/interfaces/JoiningControllerIntegrationTest.java
@@ -1,0 +1,99 @@
+package io.codechobo.event.interfaces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.EventBuilder;
+import io.codechobo.event.domain.EventStatus;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.interfaces.api.support.JoiningDto;
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Date;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-08
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@WebAppConfiguration
+@ActiveProfiles(profiles = "test")
+public class JoiningControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private Event anEvent;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JoiningRepository joiningRepository;
+
+    private EventBuilder eventBuilder;
+    private Member aMember;
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        eventBuilder = anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with이벤트상태(EventStatus.OPEN);
+        anEvent  = eventBuilder.build();
+        eventRepository.save(anEvent);
+
+        aMember = new Member(new MemberDto("member", "password", "email@gmail.com", "nickname"));
+        aMember = memberRepository.save(aMember);
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void 이벤트_응모_등록_201() throws Exception {
+        //given
+        JoiningDto joiningDto = new JoiningDto();
+        joiningDto.setJoinDate(new Date());
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(joiningDto);
+
+        //when then
+        mockMvc.perform(post("/api/joins/events/1/members/" + aMember.getSeq())
+                .content(jsonContents)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/io/codechobo/event/interfaces/WinningControllerIntegrationTest.java
+++ b/src/test/java/io/codechobo/event/interfaces/WinningControllerIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.codechobo.event.interfaces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codechobo.event.application.WinningService;
+import io.codechobo.event.domain.Event;
+import io.codechobo.event.domain.EventCategory;
+import io.codechobo.event.domain.EventStatus;
+import io.codechobo.event.domain.Joining;
+import io.codechobo.event.domain.Winning;
+import io.codechobo.event.domain.repository.EventCategoryRepository;
+import io.codechobo.event.domain.repository.EventRepository;
+import io.codechobo.event.domain.repository.JoiningRepository;
+import io.codechobo.event.domain.repository.WinningRepository;
+import io.codechobo.event.interfaces.api.support.WinningDto;
+import io.codechobo.member.domain.Member;
+import io.codechobo.member.domain.repository.MemberRepository;
+import io.codechobo.member.domain.support.MemberDto;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static io.codechobo.event.domain.EventBuilder.anEvent;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/**
+ * @author Kj Nam
+ * @since 2016-09-17
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@WebAppConfiguration
+@ActiveProfiles(profiles = "test")
+public class WinningControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WinningRepository winningRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JoiningRepository joiningRepository;
+
+    @Autowired
+    private EventCategoryRepository categoryRepository;
+
+    @MockBean
+    private WinningService winningService;
+
+    private Event anEvent;
+    private Member 응모자1;
+    private Member 응모자2;
+    private Joining joining;
+    private EventCategory category;
+
+    List<Joining> 당첨자1명리스트 = new ArrayList<>();
+    List<Joining> 당첨자2명리스트 = new ArrayList<>();
+
+
+    @Before
+    public void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        category = new EventCategory("온라인이벤트");
+        categoryRepository.save(category);
+
+        anEvent = anEvent()
+                .with이벤트명("더블예매이벤트")
+                .with설명("이벤트 설명 입니다")
+                .with시작일(new Date())
+                .with종료일(new Date())
+                .with페이지주소("/event1")
+                .with이벤트상태(EventStatus.OPEN).build();
+        anEvent = eventRepository.save(anEvent);
+
+        응모자1 = new Member(new MemberDto("member1", "password1", "email1@gmail.com", "nickname1"));
+        응모자2 = new Member(new MemberDto("member2", "password2", "email2@gmail.com", "nickname2"));
+        memberRepository.save(응모자1);
+        memberRepository.save(응모자2);
+
+        joining = new Joining(anEvent, 응모자1, new Date());
+        joining = joiningRepository.save(joining);
+        당첨자1명리스트.add(joining);
+        당첨자2명리스트.add(joining);
+        joining = new Joining(anEvent, 응모자2, new Date());
+        joining = joiningRepository.save(joining);
+        당첨자2명리스트.add(joining);
+    }
+
+    @After
+    public void tearDown() {
+        winningRepository.deleteAll();
+        joiningRepository.deleteAll();
+        eventRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    public void 새_당첨자_추첨_201() throws Exception {
+        //given
+        WinningDto winningDto = new WinningDto(new Date());
+        objectMapper = new ObjectMapper();
+        String jsonContents = objectMapper.writeValueAsString(winningDto);
+
+        mockMvc.perform(post("/api/wins/events/" + anEvent.getId() + "/joins/" + joining.getId())
+                .content(jsonContents)
+                .contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isOk());
+
+        //when
+
+        //then
+    }
+
+    @Test
+    public void 당첨자_리스트_조회() throws Exception {
+        //given
+        WinningDto winningDto = new WinningDto(new Date());
+        Winning winning = new Winning(winningDto);
+        winning.addJoins(joining);
+        winningRepository.save(winning);
+
+        //when
+        mockMvc.perform(get("/api/wins/events/" + anEvent.getId()))
+                        .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+
+        //then
+    }
+}


### PR DESCRIPTION
1. 한번에 너무 많은 양의 코드를 PR 하게 되었네요. 이런 경우 어쩌면 좋은가요?
2. 응모와 추첨에 대해서는 일단 추가하는 api만 구현했습니다.
3. 처음 이벤트 도메인을 고민할 때, 추첨에서 굳이 이벤트는 알 필요 없이 `추첨` - `응모` - `이벤트` 로 연관관계를 맺으려 했는데, JPA의 객체 그래프 탐색(?) 같은 것들이 잘 이해가 가지 않아 결국 `추첨` - `이벤트` 도 연관관계를  맺었습니다. 일단 그렇게 해결하긴 했지만 아직도 추첨이 굳이 이벤트를 알아야 하나 잘 모르겠습니다.
